### PR TITLE
Artifact names use sha instead of branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.github_pat }}
       - uses: actions/upload-artifact@v2
         with:
-          name: report-${{ github.head_ref }}
+          name: report-${{ github.sha }}
           path: report
           if-no-files-found: error
 
@@ -252,7 +252,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.github_pat }}
       - uses: actions/upload-artifact@v2
         with:
-          name: report-${{ github.head_ref }}
+          name: report-${{ github.sha }}
           path: report
           if-no-files-found: error
 

--- a/.github/workflows/test_cd.yml
+++ b/.github/workflows/test_cd.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-cd:
-    uses: pinnacles/common-cicd-actions/.github/workflows/cd.yml@main
+    uses: pinnacles/common-cicd-actions/.github/workflows/cd.yml@artifact-name
     with:
       use_ruby: true
       ruby_version: 3.1.0

--- a/.github/workflows/test_cd.yml
+++ b/.github/workflows/test_cd.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-cd:
-    uses: pinnacles/common-cicd-actions/.github/workflows/cd.yml@artifact-name
+    uses: pinnacles/common-cicd-actions/.github/workflows/cd.yml@main
     with:
       use_ruby: true
       ruby_version: 3.1.0


### PR DESCRIPTION
`actions/upload-artifact@v2` names cannot contain slashes.
So I decided to use sha instead of branch name.