### PR TITLE
Run Brakeman only ruby

### DIFF
--- a/.github/actions/reviewdog/action.yml
+++ b/.github/actions/reviewdog/action.yml
@@ -1,5 +1,17 @@
 name: Setup Reviewdog
 inputs:
+  use_ruby:
+    required: false
+    default: false
+    type: boolean
+  use_node:
+    required: false
+    default: false
+    type: boolean
+  use_go:
+    required: false
+    default: false
+    type: boolean
   github_token:
     required: true
     default: ""
@@ -23,6 +35,7 @@ runs:
     #     github_token: ${{ inputs.github_token }}
     #     fail_on_error: true
     - name: Setup reviewdog/brakeman
+      if: ${{ inputs.use_ruby == 'true' }}
       uses: reviewdog/action-brakeman@v2
       with:
         brakeman_version: 4.8.2

--- a/.github/actions/reviewdog/action.yml
+++ b/.github/actions/reviewdog/action.yml
@@ -16,6 +16,10 @@ inputs:
     required: true
     default: ""
     type: string
+  test_ci_mode:
+    required: false
+    default: false
+    type: boolean
 runs:
   using: "composite"
   steps:
@@ -35,7 +39,7 @@ runs:
     #     github_token: ${{ inputs.github_token }}
     #     fail_on_error: true
     - name: Setup reviewdog/brakeman
-      if: ${{ inputs.use_ruby == 'true' }}
+      if: ${{ inputs.use_ruby == true && inputs.test_ci_mode == false }}
       uses: reviewdog/action-brakeman@v2
       with:
         brakeman_version: 4.8.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
           go_version: ${{ inputs.go_version }}
       - uses: pinnacles/common-cicd-actions/.github/actions/reviewdog@v0.2.16
         with:
+          use_ruby: ${{ inputs.use_ruby }}
+          use_node: ${{ inputs.use_node }}
+          use_go: ${{ inputs.use_go }}
           github_token: ${{ secrets.github_pat }}
       - run: make lint
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           node_package_manager: ${{ inputs.node_package_manager }}
           use_go: ${{ inputs.use_go }}
           go_version: ${{ inputs.go_version }}
-      - uses: pinnacles/common-cicd-actions/.github/actions/reviewdog@v0.2.16
+      - uses: pinnacles/common-cicd-actions/.github/actions/reviewdog@shibukk/patch-reviewdog
         with:
           use_ruby: ${{ inputs.use_ruby }}
           use_node: ${{ inputs.use_node }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,11 @@ on:
         required: false
         default: false
         type: boolean
+      test_ci_mode:
+        description: 'whether test_ci or not'
+        required: false
+        default: false
+        type: boolean
     secrets:
       github_pat:
         description: 'Personal Access Token of bot user'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
           use_node: ${{ inputs.use_node }}
           use_go: ${{ inputs.use_go }}
           github_token: ${{ secrets.github_pat }}
+          test_ci_mode: ${{ inputs.test_ci_mode }}
       - run: make lint
         env:
           ACTION_TYPE: CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           node_package_manager: ${{ inputs.node_package_manager }}
           use_go: ${{ inputs.use_go }}
           go_version: ${{ inputs.go_version }}
-      - uses: pinnacles/common-cicd-actions/.github/actions/reviewdog@shibukk/patch-reviewdog
+      - uses: pinnacles/common-cicd-actions/.github/actions/reviewdog@v0.2.16
         with:
           use_ruby: ${{ inputs.use_ruby }}
           use_node: ${{ inputs.use_node }}

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-ci-ruby:
-    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@shibukk/patch-reviewdog
+    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@main
     with:
       use_ruby: true
       ruby_version: 3.1.0
@@ -21,7 +21,7 @@ jobs:
       github_pat: dummy
 
   test-ci-node:
-    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@shibukk/patch-reviewdog
+    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@main
     with:
       use_ruby: false
       ruby_version: ""
@@ -35,7 +35,7 @@ jobs:
       github_pat: dummy
 
   test-ci-go:
-    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@shibukk/patch-reviewdog
+    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@main
     with:
       use_ruby: false
       ruby_version: ""
@@ -49,7 +49,7 @@ jobs:
       github_pat: dummy
 
   test-ci-ruby-and-node:
-    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@shibukk/patch-reviewdog
+    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@main
     with:
       use_ruby: true
       ruby_version: 3.1.0
@@ -63,7 +63,7 @@ jobs:
       github_pat: dummy
 
   test-ci-test-in-parallel:
-    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@shibukk/patch-reviewdog
+    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@main
     with:
       use_ruby: true
       ruby_version: 3.1.0

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -16,6 +16,7 @@ jobs:
       node_package_manager: ""
       use_go: false
       go_version: ""
+      test_ci_mode: true
     secrets:
       github_pat: dummy
 
@@ -29,6 +30,7 @@ jobs:
       node_package_manager: "yarn"
       use_go: false
       go_version: ""
+      test_ci_mode: true
     secrets:
       github_pat: dummy
 
@@ -42,6 +44,7 @@ jobs:
       node_package_manager: ""
       use_go: true
       go_version: 1.17.6
+      test_ci_mode: true
     secrets:
       github_pat: dummy
 
@@ -55,6 +58,7 @@ jobs:
       node_package_manager: "yarn"
       use_go: false
       go_version: ""
+      test_ci_mode: true
     secrets:
       github_pat: dummy
 
@@ -69,5 +73,6 @@ jobs:
       use_go: false
       go_version: ""
       test_in_parallel: true
+      test_ci_mode: true
     secrets:
       github_pat: dummy

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-ci-ruby:
-    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@main
+    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@shibukk/patch-reviewdog
     with:
       use_ruby: true
       ruby_version: 3.1.0
@@ -20,7 +20,7 @@ jobs:
       github_pat: dummy
 
   test-ci-node:
-    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@main
+    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@shibukk/patch-reviewdog
     with:
       use_ruby: false
       ruby_version: ""
@@ -33,7 +33,7 @@ jobs:
       github_pat: dummy
 
   test-ci-go:
-    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@main
+    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@shibukk/patch-reviewdog
     with:
       use_ruby: false
       ruby_version: ""
@@ -46,7 +46,7 @@ jobs:
       github_pat: dummy
 
   test-ci-ruby-and-node:
-    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@main
+    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@shibukk/patch-reviewdog
     with:
       use_ruby: true
       ruby_version: 3.1.0
@@ -59,7 +59,7 @@ jobs:
       github_pat: dummy
 
   test-ci-test-in-parallel:
-    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@main
+    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@shibukk/patch-reviewdog
     with:
       use_ruby: true
       ruby_version: 3.1.0


### PR DESCRIPTION
Brakeman need only ruby.
And Skip on test_ci.yml. ([reason](https://github.com/pinnacles/common-cicd-actions/runs/6871568321?check_suite_focus=true))

CI fails because it use the main branch, but we have confirmed that there is no problem after the release.