### PR TITLE
Upgrade Brakeman for Ruby3

### DIFF
--- a/.github/actions/reviewdog/action.yml
+++ b/.github/actions/reviewdog/action.yml
@@ -42,7 +42,6 @@ runs:
       if: ${{ inputs.use_ruby == true && inputs.test_ci_mode == false }}
       uses: reviewdog/action-brakeman@v2
       with:
-        brakeman_version: 5.2.2
         reporter: github-pr-review
         github_token: ${{ inputs.github_token }}
         fail_on_error: true

--- a/.github/actions/reviewdog/action.yml
+++ b/.github/actions/reviewdog/action.yml
@@ -42,7 +42,7 @@ runs:
       if: ${{ inputs.use_ruby == true && inputs.test_ci_mode == false }}
       uses: reviewdog/action-brakeman@v2
       with:
-        brakeman_version: 4.8.2
+        brakeman_version: 5.2.2
         reporter: github-pr-review
         github_token: ${{ inputs.github_token }}
         fail_on_error: true


### PR DESCRIPTION
Upgrade Brakeman to the latest version for Ruby3.