### PR TITLE
bumpup actions/reviewdog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           node_package_manager: ${{ inputs.node_package_manager }}
           use_go: ${{ inputs.use_go }}
           go_version: ${{ inputs.go_version }}
-      - uses: pinnacles/common-cicd-actions/.github/actions/reviewdog@v0.2.16
+      - uses: pinnacles/common-cicd-actions/.github/actions/reviewdog@v0.3.0
         with:
           use_ruby: ${{ inputs.use_ruby }}
           use_node: ${{ inputs.use_node }}


### PR DESCRIPTION
Apply it.
[Run Brakeman only ruby by shibukk · Pull Request #24 · pinnacles/common-cicd-actions](https://github.com/pinnacles/common-cicd-actions/pull/24)

CI fails because it use the main branch, but we have confirmed that there is no problem after the release.