### PR TITLE
Bumpup actions/reviewdog from 0.4.0 to 0.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           node_package_manager: ${{ inputs.node_package_manager }}
           use_go: ${{ inputs.use_go }}
           go_version: ${{ inputs.go_version }}
-      - uses: pinnacles/common-cicd-actions/.github/actions/reviewdog@v0.4.0
+      - uses: pinnacles/common-cicd-actions/.github/actions/reviewdog@v0.6.0
         with:
           use_ruby: ${{ inputs.use_ruby }}
           use_node: ${{ inputs.use_node }}


### PR DESCRIPTION
Apply it.
[Added rubocop to reviewdog by shibukk · Pull Request #33 · pinnacles/common-cicd-actions](https://github.com/pinnacles/common-cicd-actions/pull/33)