### PR TITLE
bump configure-aws-credentials version

### DIFF
--- a/.github/actions/aws-oidc-auth/action.yaml
+++ b/.github/actions/aws-oidc-auth/action.yaml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
   - name: Configure AWS Credentials
-    uses: aws-actions/configure-aws-credentials@b8c74de753fbcb4868bf2011fb2e15826ce973af
+    uses: aws-actions/configure-aws-credentials@v1
     with:
       aws-region: ${{ inputs.aws-region }}
       role-to-assume: ${{ inputs.role-to-assume }}


### PR DESCRIPTION
Due to following error, but I'm not sure for bumping version to become some workaround or not.

```
Error: Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers
```

According to this entry, it was mentioned that possibly become a workaround that to bump up configure-aws-credentials actions version. 
ref: https://tech.guitarrapc.com/entry/2021/11/05/025150

One more thing, there is missing permission id-token in post-process, that is mentioned in README.
ref: https://github.com/aws-actions/configure-aws-credentials

I'm gonna deal with it in another pull-request https://github.com/pinnacles/common-cicd-actions/pull/37 