### PR TITLE
Add reviewdog rails

### DIFF
--- a/.github/actions/reviewdog/rails/action.yml
+++ b/.github/actions/reviewdog/rails/action.yml
@@ -1,14 +1,10 @@
-name: Setup Reviewdog
+name: Setup Reviewdog for Rails
 inputs:
-  use_ruby:
+  use_rubocop:
     required: false
     default: false
     type: boolean
-  use_node:
-    required: false
-    default: false
-    type: boolean
-  use_go:
+  use_brakeman:
     required: false
     default: false
     type: boolean
@@ -16,32 +12,22 @@ inputs:
     required: true
     default: ""
     type: string
-  test_ci_mode:
-    required: false
-    default: false
-    type: boolean
 runs:
   using: "composite"
   steps:
-    # - name: Setup reviewdog/eslint
-    #   uses: reviewdog/action-eslint@v1
-    #   with:
-    #     eslint_flags: 'frontend/'
-    #     reporter: github-pr-review
-    #     github_token: ${{ inputs.github_token }}
-    #     fail_on_error: true
     - name: Setup reviewdog/rubocop
+      if: ${{ inputs.use_rubocop == true }}
       uses: reviewdog/action-rubocop@v2
       with:
+        github_token: ${{ inputs.github_token }}
         rubocop_version: gemfile
         rubocop_extensions: rubocop-rails:gemfile rubocop-rspec:gemfile rubocop-performance:gemfile
         reporter: github-pr-review
-        github_token: ${{ inputs.github_token }}
         fail_on_error: true
     - name: Setup reviewdog/brakeman
-      if: ${{ inputs.use_ruby == true && inputs.test_ci_mode == false }}
+      if: ${{ inputs.use_brakeman == true }}
       uses: reviewdog/action-brakeman@v2
       with:
-        reporter: github-pr-review
         github_token: ${{ inputs.github_token }}
+        reporter: github-pr-review
         fail_on_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,13 +96,6 @@ jobs:
           node_package_manager: ${{ inputs.node_package_manager }}
           use_go: ${{ inputs.use_go }}
           go_version: ${{ inputs.go_version }}
-      - uses: pinnacles/common-cicd-actions/.github/actions/reviewdog@v0.6.0
-        with:
-          use_ruby: ${{ inputs.use_ruby }}
-          use_node: ${{ inputs.use_node }}
-          use_go: ${{ inputs.use_go }}
-          github_token: ${{ secrets.github_pat }}
-          test_ci_mode: ${{ inputs.test_ci_mode }}
       - run: make lint
         env:
           ACTION_TYPE: CI

--- a/.github/workflows/reviewdog_rails.yml
+++ b/.github/workflows/reviewdog_rails.yml
@@ -1,0 +1,30 @@
+name: Common reviewdog reusable workflow for Rails project
+
+on:
+  workflow_call:
+    inputs:
+      use_rubocop:
+        description: 'whether use rubocop or not'
+        required: false
+        default: false
+        type: boolean
+      use_brakeman:
+        description: 'whether use brakeman or not'
+        required: false
+        type: string
+    secrets:
+      github_pat:
+        description: 'Personal Access Token of bot user'
+        required: false
+
+jobs:
+  review:
+    name: review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: pinnacles/common-cicd-actions/.github/actions/reviewdog/rails@v0.6.0
+        with:
+          use_rubocop: ${{ inputs.use_rubocop }}
+          use_brakeman: ${{ inputs.use_brakeman }}
+          github_token: ${{ secrets.github_pat }}

--- a/.github/workflows/test_reviewdog_rails.yml
+++ b/.github/workflows/test_reviewdog_rails.yml
@@ -1,0 +1,15 @@
+name: Test reviewdog_rails.yml
+
+on:
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  test-reviewdog-rails:
+    uses: pinnacles/common-cicd-actions/.github/workflows/reviewdog_rails.yml@main
+    with:
+      use_rubocop: true
+      use_brakeman: true
+    secrets:
+      github_pat: dummy


### PR DESCRIPTION
Add reviewdog_rails.yml as a stand along workflow. Then I remove reviewdog action from ci.yml.
Users need to use reviewdog_rails.yml exprecitly if they wanna use reviewdog like following from now on:

```yaml
name: reviewdog for Rails

on:
  pull_request:

jobs:
  runner:
    uses: pinnacles/common-cicd-actions/.github/workflows/reviewdog_rails.yml@v0.7.4
    with:
      use_rubocop: true
      use_brakeman: true
    secrets:
      github_pat: ${{ secrets.GITHUB_TOKEN }}
```
