### PR TITLE
fix: bump version for actions/reveiwdog/rails

### DIFF
--- a/.github/workflows/reviewdog_rails.yml
+++ b/.github/workflows/reviewdog_rails.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: pinnacles/common-cicd-actions/.github/actions/reviewdog/rails@v0.6.0
+      - uses: pinnacles/common-cicd-actions/.github/actions/reviewdog/rails@v0.8.0
         with:
           use_rubocop: ${{ inputs.use_rubocop }}
           use_brakeman: ${{ inputs.use_brakeman }}


### PR DESCRIPTION
pinnacles/common-cicd-actions/.github/actions/reviewdog/rails@v0.6.0 is not existed.