### PR TITLE
fix: add test that ALL_CHANGED_FILES should not empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     name: resolve dependencies
     runs-on: ubuntu-latest
     outputs:
-      all_changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
+      all_changed_files: ${{ steps.changed-files.outputs.all_modified_files }}
       pull_request_number: ${{ steps.pr.outputs.pull_request_number }}
       allow_simplecov_action: ${{ github.ref_name == 'master' || steps.pr.outputs.pull_request_number != '' }}
     steps:

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-ci-ruby:
-    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@add-test
+    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@main
     with:
       use_ruby: true
       ruby_version: 3.1.0

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-ci-ruby:
-    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@main
+    uses: pinnacles/common-cicd-actions/.github/workflows/ci.yml@add-test
     with:
       use_ruby: true
       ruby_version: 3.1.0

--- a/test.sh
+++ b/test.sh
@@ -35,3 +35,10 @@ fi
 if [ -n "${GITHUB_TOKEN}" ]; then
 	test "${GITHUB_TOKEN}" = dummy
 fi
+
+if [ -z "${ALL_CHANGED_FILES}" ]; then
+	echo "ALL_CHANGED_FILES: ${ALL_CHANGED_FILES}"
+	exit 1
+else
+	echo "ALL_CHANGED_FILES: ${ALL_CHANGED_FILES}"
+fi


### PR DESCRIPTION
add test that ALL_CHANGED_FILES should not empty

I saw the case that empty value of ALL_CHANGED_FILES environment variable is passed through to the user.
I trid to test and worked correctly that I replaced `all_changed_files` to `all_modified_files` in [6ef222a](https://github.com/pinnacles/common-cicd-actions/pull/51/commits/6ef222abbccd240402489dcf5777cc0d023b960f).