### PR TITLE
fix: github action runner ubuntu-18.04 is fully unsupported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
     if: ${{ inputs.use_mysql == true && inputs.test_in_parallel == false }}
     name: execute `make test`
     needs: dependency-resolution
-    runs-on: ubuntu-${{ startsWith(inputs.mysql_version, '5') && '18.04' || 'latest' }}
+    runs-on: ubuntu-latest
     services:
       db:
         image: mysql:${{ inputs.mysql_version }}
@@ -253,7 +253,7 @@ jobs:
     if: ${{ inputs.use_mysql == true && inputs.test_in_parallel == true }}
     name: execute `make test`
     needs: dependency-resolution
-    runs-on: ubuntu-${{ startsWith(inputs.mysql_version, '5') && '18.04' || 'latest' }}
+    runs-on: ubuntu-latest
     services:
       db:
         image: mysql:${{ inputs.mysql_version }}
@@ -316,7 +316,7 @@ jobs:
       test-in-parallel,
       test-in-parallel-with-mysql,
     ]
-    runs-on: ubuntu-${{ startsWith(inputs.mysql_version, '5') && '18.04' || 'latest' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: pinnacles/common-cicd-actions/.github/actions/setup-lang@v0.13.0

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -88,7 +88,7 @@ jobs:
     if: ${{ inputs.use_mysql == true && inputs.test_in_parallel == false }}
     name: execute `make test`
     needs: dependency-resolution
-    runs-on: ubuntu-${{ startsWith(inputs.mysql_version, '5') && '18.04' || 'latest' }}
+    runs-on: ubuntu-latest
     services:
       db:
         image: mysql:${{ inputs.mysql_version }}
@@ -178,7 +178,7 @@ jobs:
     if: ${{ inputs.use_mysql == true && inputs.test_in_parallel == true }}
     name: execute `make test`
     needs: dependency-resolution
-    runs-on: ubuntu-${{ startsWith(inputs.mysql_version, '5') && '18.04' || 'latest' }}
+    runs-on: ubuntu-latest
     services:
       db:
         image: mysql:${{ inputs.mysql_version }}
@@ -240,7 +240,7 @@ jobs:
       test-in-parallel,
       test-in-parallel-with-mysql,
     ]
-    runs-on: ubuntu-${{ startsWith(inputs.mysql_version, '5') && '18.04' || 'latest' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: pinnacles/common-cicd-actions/.github/actions/setup-lang@v0.1.0


### PR DESCRIPTION
## Summary
- https://github.com/actions/runner-images/issues/6002

## Actual Behavior
- steps of test are cancelled

<img width="1124" alt="image" src="https://user-images.githubusercontent.com/24871281/229745586-91e5948b-005e-4121-8834-a0b967311121.png">

## Expected Behavior
- steps of test are running